### PR TITLE
Remove duplicate content

### DIFF
--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -8,7 +8,7 @@ import { filterByLanguage } from '../../i18n/utils';
 
 // Get featured projects, sorted by order
 const allProjects = await getCollection('projects');
-const featuredProjects = allProjects
+const featuredProjects = filterByLanguage(allProjects, 'es')
 	.filter(project => project.data.featured)
 	.sort((a, b) => a.data.order - b.data.order)
 	.slice(0, 3); // Show only top 3 featured projects

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import { filterByLanguage } from '@/i18n/utils';
 
 // Get featured projects, sorted by order
 const allProjects = await getCollection('projects');
-const featuredProjects = allProjects
+const featuredProjects = filterByLanguage(allProjects, 'en')
 	.filter(project => project.data.featured)
 	.sort((a, b) => a.data.order - b.data.order)
 	.slice(0, 3); // Show only top 3 featured projects


### PR DESCRIPTION
Add language filtering to main pages to prevent duplicate featured projects.

Previously, the main pages (both English and Spanish) were loading all projects from both language directories without filtering, leading to duplicate entries when a project existed in both `en/` and `es/` content folders.

---
<a href="https://cursor.com/background-agent?bcId=bc-3afe1a41-67a8-40ba-875a-62b48adcfbdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3afe1a41-67a8-40ba-875a-62b48adcfbdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

